### PR TITLE
feat: 🎸 detect cyclical dependencies, via CLI and before pack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "monopacker",
-	"version": "0.1.16",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/Packer.ts
+++ b/src/Packer.ts
@@ -159,7 +159,14 @@ export class Packer {
 		const sourceExists = await fs.pathExists(this.options.source);
 		const sourcePkgExists = await fs.pathExists(resolve(this.options.source, 'package.json'));
 
-		return sourceExists && sourcePkgExists;
+		const sourcesExists = sourceExists && sourcePkgExists;
+		const adapterValidationResult = await this.adapter.validate();
+
+		if (sourcesExists && adapterValidationResult.valid) {
+			return true;
+		}
+
+		throw adapterValidationResult.message || 'Invalid packer configuration';
 	}
 
 	/**

--- a/src/adapter/Adapter.ts
+++ b/src/adapter/Adapter.ts
@@ -3,6 +3,10 @@ import { IAnalytics, IPackerOptions, IAdapter } from '../types';
 export class Adapter implements IAdapter {
 	constructor(protected cwd: string, protected options: IPackerOptions) {}
 
+	public async validate() {
+		return { valid: true };
+	}
+
 	public async analyze(): Promise<IAnalytics> {
 		throw new Error('Not implemented');
 	}

--- a/src/bin/commands/analyze.ts
+++ b/src/bin/commands/analyze.ts
@@ -2,7 +2,6 @@ import { Packer } from '../../Packer';
 import ora from 'ora';
 import { displayPath } from '../../utils';
 
-Packer;
 export async function analyze(cwd: string, source: string) {
 	const spinner = ora('Creating packer instance');
 	spinner.frame();

--- a/src/bin/commands/index.ts
+++ b/src/bin/commands/index.ts
@@ -1,2 +1,3 @@
 export * from './analyze';
 export * from './pack';
+export * from './validate';

--- a/src/bin/commands/validate.ts
+++ b/src/bin/commands/validate.ts
@@ -1,0 +1,29 @@
+import { Packer } from '../../Packer';
+import ora from 'ora';
+import { displayPath } from '../../utils';
+
+export async function validate(cwd: string, source: string) {
+	const spinner = ora('Creating packer instance');
+	spinner.frame();
+	spinner.start();
+
+	const packer = new Packer({
+		cwd,
+		source,
+		target: 'packed',
+		hooks: {
+			init: [
+				async () => {
+					spinner.succeed(`Initialized packer v${Packer.version} for ${displayPath(process.cwd(), source)}`);
+				}
+			]
+		}
+	});
+
+	try {
+		await packer.validate();
+		spinner.succeed(`Your project is ready to get packed!`);
+	} catch (err) {
+		spinner.fail(`${err || 'Project contains issues, please check the docs'}`);
+	}
+}

--- a/src/bin/monopacker-cli.ts
+++ b/src/bin/monopacker-cli.ts
@@ -3,7 +3,7 @@
 
 import { resolve } from 'path';
 import * as commander from 'commander';
-import { analyze, pack } from './commands';
+import { analyze, pack, validate } from './commands';
 import { AdapterLerna } from '../adapter/Lerna';
 
 const program = new commander.Command();
@@ -14,6 +14,22 @@ program
 	.option('-d, --debug', 'Enable debug mode', false)
 	.option('-v, --verbose', 'Silent mode', false)
 	.allowUnknownOption(false);
+
+program
+	.command('validate <source>')
+	.alias('v')
+	.description('Checks if a package is packable by resolving all packages theoretically')
+	.option('-r, --root <dir>', 'Set a custom root directory, default: process.cwd()', process.cwd())
+	.action(async (source, { root, verbose = false }) => {
+		await validate(resolve(root), source);
+	})
+	.on('--help', () => {
+		console.log('');
+		console.log('Examples:');
+		console.log('');
+		console.log('  $ monpacker validate ./packages/main');
+		console.log('  $ monopacker v packages/main');
+	});
 
 program
 	.command('analyze <source>')

--- a/src/types/Adapter.ts
+++ b/src/types/Adapter.ts
@@ -2,6 +2,10 @@ import { IAnalytics, IPackerOptions } from './Runtime';
 
 export interface IAdapter {
 	analyze(): Promise<IAnalytics>;
+	validate(): Promise<{
+		valid: boolean;
+		message?: string;
+	}>;
 }
 
 export interface IAdapterConstructable {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,9 @@ export function getLernaPackages(root: string) {
 
 				if (!isDuplicate.length && pkg && pkg !== null) {
 					if (!pkg.name || !pkg.version) {
-						console.log(`Invalid package ${pkg.name || '<unknown>'} in ${ref}: name or version missing`);
+						throw new Error(
+							`Invalid package ${pkg.name || '<unknown>'} in ${ref}: name or version missing`
+						);
 					}
 					acc.push({
 						name: pkg.name,
@@ -132,7 +134,7 @@ export function getLernaPackages(root: string) {
 				}
 			} catch (err) {
 				/* istanbul ignore next */
-				console.log(err);
+				throw err;
 			}
 			return acc;
 		},

--- a/test/fixtures/cyclical/lerna.json
+++ b/test/fixtures/cyclical/lerna.json
@@ -1,0 +1,3 @@
+{
+  "packages": ["./packages/*"]
+}

--- a/test/fixtures/cyclical/package.json
+++ b/test/fixtures/cyclical/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fixture-cyclical",
+  "devDependencies": {
+    "lerna": "3.15.0"
+  }
+}

--- a/test/fixtures/cyclical/packages/a/package.json
+++ b/test/fixtures/cyclical/packages/a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/cyclical-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "@fixture/cyclical-b": "*"
+  }
+}

--- a/test/fixtures/cyclical/packages/b/package.json
+++ b/test/fixtures/cyclical/packages/b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/cyclical-b",
+  "version": "1.0.0",
+  "dependencies": {
+    "@fixture/cyclical-a": "*"
+  }
+}


### PR DESCRIPTION
- adds a new required method to any adapter called `validate(): Promise<boolean> | throws Error`
- adds the new command `monopacker validate <source>` / `monopacker v <source>`
- validation will be invoked before analytics can start to make sure the project is valid to pack